### PR TITLE
fix: application properties changed to env variables.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### Env Variables ###
+
+.env

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,12 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>dotenv-java</artifactId>
+            <version>3.0.0</version>
+        </dependency>
+
 
     </dependencies>
 

--- a/src/main/java/org/test/audit_management/AuditManagementApplication.java
+++ b/src/main/java/org/test/audit_management/AuditManagementApplication.java
@@ -1,5 +1,6 @@
 package org.test.audit_management;
 
+import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,6 +8,14 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class AuditManagementApplication {
 
     public static void main(String[] args) {
+
+        Dotenv dotenv = Dotenv.configure()
+                .filename("env.auditmgmt")
+                .load();
+        System.setProperty("DB_URL", dotenv.get("DB_URL"));
+        System.setProperty("DB_USERNAME", dotenv.get("DB_USERNAME"));
+        System.setProperty("DB_PASSWORD", dotenv.get("DB_PASSWORD"));
+
         SpringApplication.run(AuditManagementApplication.class, args);
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=Audit Management
-spring.datasource.url = jdbc:postgresql://localhost:5432/audit-mgmt
-spring.datasource.username = postgres
-spring.datasource.password = password
-spring.jpa.hibernate.ddl-auto = update
+spring.datasource.url=${DB_URL}
+spring.datasource.username=${DB_USERNAME}
+spring.datasource.password=${DB_PASSWORD}
 
-spring.jpa.properties.hibernate.jdbc.lob.non_contextual_contextual_creation=true
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true


### PR DESCRIPTION
The first version of this application included a major security problem. By mistake, I included the credentials for the DB on the application properties. The error was corrected, the credentials changed and the following changes were made:

Application properties changed: the actual credentials were changed to direct to environment variables;
Environment variable created: including valid credentials;
.gitignore filed changed to not versionate the file with the env variables.
pom.xml changed to include the dotenv java.
Main method changed to set the env variables before initiating the application.